### PR TITLE
feat: OPMLとテキスト形式のインポート/エクスポート機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,36 @@ termfeed favorite <ARTICLE_ID>
 termfeed show <ARTICLE_ID>
 ```
 
+#### フィードのエクスポート/インポート
+
+```bash
+# フィードをOPML形式でエクスポート（デフォルト）
+termfeed export
+# -> subscriptions.opml に出力
+
+# ファイル名を指定してエクスポート
+termfeed export my-feeds.opml
+
+# テキスト形式（1行1URL）でエクスポート
+termfeed export feeds.txt --format text
+
+# 拡張子から自動判別（.txt → テキスト形式）
+termfeed export feeds.txt
+
+# OPMLファイルからインポート
+termfeed import subscriptions.opml
+
+# テキストファイルからインポート（1行1URL）
+termfeed import feeds.txt
+
+# フォーマットを明示的に指定
+termfeed import feeds.xml --format opml
+```
+
+**対応フォーマット：**
+- **OPML形式**: 標準的なRSSリーダー間でのデータ移行に使用（.opml, .xml）
+- **テキスト形式**: シンプルな1行1URLのフォーマット。コメント行（#で始まる）対応
+
 ### データベースの場所
 
 SQLiteデータベースはデフォルトで `./termfeed.db` に作成されます。

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -1,0 +1,61 @@
+import { Command } from 'commander';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import chalk from 'chalk';
+import { DatabaseManager } from '../../models/database.js';
+import { FeedModel } from '../../models/feed.js';
+import { OPMLService, ExportFormat } from '../../services/opml.js';
+
+export const exportCommand = new Command('export')
+  .description('Export feed subscriptions to OPML or text file')
+  .argument('[file]', 'output file path (default: termfeed-export.opml)')
+  .option('-f, --format <format>', 'export format (opml or text)', 'auto')
+  .action(async (file?: string, options?: { format?: string }) => {
+    try {
+      const dbManager = new DatabaseManager();
+      dbManager.migrate();
+      const feedModel = new FeedModel(dbManager);
+
+      // すべてのフィードを取得
+      const feeds = feedModel.findAll();
+
+      if (feeds.length === 0) {
+        console.log(chalk.yellow('No feeds to export'));
+        return;
+      }
+
+      // ファイルパスの決定
+      const outputPath = file || 'subscriptions.opml';
+      const absolutePath = path.resolve(outputPath);
+
+      // 形式の決定
+      let format: ExportFormat;
+      if (options?.format === 'auto') {
+        format = OPMLService.detectFormat(outputPath);
+      } else if (options?.format === 'opml' || options?.format === 'text') {
+        format = options.format;
+      } else {
+        console.error(chalk.red('Invalid format. Use "opml" or "text"'));
+        process.exit(1);
+      }
+
+      // 指定された形式でエクスポート
+      let content: string;
+      if (format === 'opml') {
+        content = OPMLService.exportToOPML(feeds);
+      } else {
+        content = OPMLService.exportToText(feeds);
+      }
+
+      // ファイルに書き込み
+      await fs.writeFile(absolutePath, content, 'utf-8');
+
+      const formatName = format === 'opml' ? 'OPML' : 'text';
+      console.log(
+        chalk.green(`✓ Exported ${feeds.length} feeds to ${absolutePath} (${formatName} format)`)
+      );
+    } catch (error) {
+      console.error(chalk.red('Error exporting feeds:'), error);
+      process.exit(1);
+    }
+  });

--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -8,11 +8,12 @@ import { OPMLService, ExportFormat } from '../../services/opml.js';
 
 export const exportCommand = new Command('export')
   .description('Export feed subscriptions to OPML or text file')
-  .argument('[file]', 'output file path (default: termfeed-export.opml)')
+  .argument('[file]', 'output file path (default: subscriptions.opml)')
   .option('-f, --format <format>', 'export format (opml or text)', 'auto')
   .action(async (file?: string, options?: { format?: string }) => {
+    const dbManager = new DatabaseManager();
+
     try {
-      const dbManager = new DatabaseManager();
       dbManager.migrate();
       const feedModel = new FeedModel(dbManager);
 
@@ -57,5 +58,7 @@ export const exportCommand = new Command('export')
     } catch (error) {
       console.error(chalk.red('Error exporting feeds:'), error);
       process.exit(1);
+    } finally {
+      dbManager.close();
     }
   });

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -14,6 +14,8 @@ export const importCommand = new Command('import')
   .argument('<file>', 'file to import')
   .option('-f, --format <format>', 'import format (opml or text)', 'auto')
   .action(async (file: string, options?: { format?: string }) => {
+    let dbManager: DatabaseManager | null = null;
+
     try {
       const absolutePath = path.resolve(file);
 
@@ -55,7 +57,7 @@ export const importCommand = new Command('import')
       console.log(chalk.blue(`Found ${urls.length} feed URLs to import...`));
 
       // データベースとサービスの初期化
-      const dbManager = new DatabaseManager();
+      dbManager = new DatabaseManager();
       dbManager.migrate();
       const feedModel = new FeedModel(dbManager);
       const articleModel = new ArticleModel(dbManager);
@@ -97,5 +99,9 @@ export const importCommand = new Command('import')
     } catch (error) {
       console.error(chalk.red('Error importing feeds:'), error);
       process.exit(1);
+    } finally {
+      if (dbManager) {
+        dbManager.close();
+      }
     }
   });

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -1,0 +1,97 @@
+import { Command } from 'commander';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import chalk from 'chalk';
+import { DatabaseManager } from '../../models/database.js';
+import { FeedService } from '../../services/feed-service.js';
+import { OPMLService } from '../../services/opml.js';
+import { DuplicateFeedError } from '../../services/errors.js';
+
+export const importCommand = new Command('import')
+  .description('Import feed subscriptions from OPML or text file')
+  .argument('<file>', 'file to import')
+  .option('-f, --format <format>', 'import format (opml or text)', 'auto')
+  .action(async (file: string, options?: { format?: string }) => {
+    try {
+      const absolutePath = path.resolve(file);
+
+      // ファイルの存在確認
+      try {
+        await fs.access(absolutePath);
+      } catch {
+        console.error(chalk.red(`File not found: ${absolutePath}`));
+        process.exit(1);
+      }
+
+      // ファイルを読み込み
+      const content = await fs.readFile(absolutePath, 'utf-8');
+
+      // 形式の決定
+      let format: 'opml' | 'text';
+      if (options?.format === 'auto') {
+        format = OPMLService.detectFormatFromContent(content);
+      } else if (options?.format === 'opml' || options?.format === 'text') {
+        format = options.format;
+      } else {
+        console.error(chalk.red('Invalid format. Use "opml" or "text"'));
+        process.exit(1);
+      }
+
+      // URLを抽出
+      let urls: string[];
+      if (format === 'opml') {
+        urls = OPMLService.parseOPML(content);
+      } else {
+        urls = OPMLService.parseText(content);
+      }
+
+      if (urls.length === 0) {
+        console.log(chalk.yellow('No valid feed URLs found in the file'));
+        return;
+      }
+
+      console.log(chalk.blue(`Found ${urls.length} feed URLs to import...`));
+
+      // データベースとサービスの初期化
+      const dbManager = new DatabaseManager();
+      dbManager.migrate();
+      const feedService = new FeedService(dbManager);
+
+      // 各URLを追加
+      let successCount = 0;
+      let duplicateCount = 0;
+      let errorCount = 0;
+
+      for (const url of urls) {
+        try {
+          console.log(chalk.gray(`Adding ${url}...`));
+          await feedService.addFeed(url);
+          successCount++;
+          console.log(chalk.green(`✓ Added ${url}`));
+        } catch (error) {
+          if (error instanceof DuplicateFeedError) {
+            duplicateCount++;
+            console.log(chalk.yellow(`⚠ Skipped (already exists): ${url}`));
+          } else {
+            errorCount++;
+            console.error(chalk.red(`✗ Failed to add ${url}:`), error);
+          }
+        }
+      }
+
+      // 結果のサマリー
+      console.log('\n' + chalk.bold('Import Summary:'));
+      if (successCount > 0) {
+        console.log(chalk.green(`✓ Successfully imported: ${successCount} feeds`));
+      }
+      if (duplicateCount > 0) {
+        console.log(chalk.yellow(`⚠ Already existed: ${duplicateCount} feeds`));
+      }
+      if (errorCount > 0) {
+        console.log(chalk.red(`✗ Failed to import: ${errorCount} feeds`));
+      }
+    } catch (error) {
+      console.error(chalk.red('Error importing feeds:'), error);
+      process.exit(1);
+    }
+  });

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import chalk from 'chalk';
 import { DatabaseManager } from '../../models/database.js';
+import { FeedModel } from '../../models/feed.js';
+import { ArticleModel } from '../../models/article.js';
 import { FeedService } from '../../services/feed-service.js';
 import { OPMLService } from '../../services/opml.js';
 import { DuplicateFeedError } from '../../services/errors.js';
@@ -55,7 +57,9 @@ export const importCommand = new Command('import')
       // データベースとサービスの初期化
       const dbManager = new DatabaseManager();
       dbManager.migrate();
-      const feedService = new FeedService(dbManager);
+      const feedModel = new FeedModel(dbManager);
+      const articleModel = new ArticleModel(dbManager);
+      const feedService = new FeedService(feedModel, articleModel);
 
       // 各URLを追加
       let successCount = 0;

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -4,3 +4,5 @@ export { createUpdateCommand } from './update.js';
 export { createListCommand } from './feeds.js';
 export { createRmCommand } from './rm.js';
 export { createTuiCommand } from './tui.js';
+export { exportCommand } from './export.js';
+export { importCommand } from './import.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import {
   createListCommand,
   createRmCommand,
   createTuiCommand,
+  exportCommand,
+  importCommand,
 } from './cli/commands/index.js';
 
 export const VERSION = '0.1.0';
@@ -27,6 +29,8 @@ program.addCommand(createUpdateCommand());
 program.addCommand(createListCommand());
 program.addCommand(createRmCommand());
 program.addCommand(createTuiCommand());
+program.addCommand(exportCommand);
+program.addCommand(importCommand);
 
 // Main CLI entry point
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/src/services/opml.test.ts
+++ b/src/services/opml.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect } from 'vitest';
+import { OPMLService } from './opml.js';
+import { Feed } from '../models/types.js';
+
+describe('OPMLService', () => {
+  const mockFeeds: Feed[] = [
+    {
+      id: 1,
+      url: 'https://example.com/feed1.rss',
+      title: 'Example Feed 1',
+      description: 'First test feed',
+      last_updated_at: new Date('2025-01-01'),
+      created_at: new Date('2025-01-01'),
+    },
+    {
+      id: 2,
+      url: 'https://example.com/feed2.xml',
+      title: 'Feed with <special> & characters',
+      description: 'Test "quotes" and \'apostrophes\'',
+      last_updated_at: new Date('2025-01-01'),
+      created_at: new Date('2025-01-01'),
+    },
+  ];
+
+  describe('exportToOPML', () => {
+    it('should export feeds to valid OPML format', () => {
+      const opml = OPMLService.exportToOPML(mockFeeds);
+
+      expect(opml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+      expect(opml).toContain('<opml version="2.0">');
+      expect(opml).toContain('<head>');
+      expect(opml).toContain('<title>termfeed subscriptions</title>');
+      expect(opml).toContain('</head>');
+      expect(opml).toContain('<body>');
+      expect(opml).toContain('</body>');
+      expect(opml).toContain('</opml>');
+    });
+
+    it('should include all feed URLs', () => {
+      const opml = OPMLService.exportToOPML(mockFeeds);
+
+      expect(opml).toContain('xmlUrl="https://example.com/feed1.rss"');
+      expect(opml).toContain('xmlUrl="https://example.com/feed2.xml"');
+    });
+
+    it('should escape XML special characters', () => {
+      const opml = OPMLService.exportToOPML(mockFeeds);
+
+      expect(opml).toContain('title="Feed with &lt;special&gt; &amp; characters"');
+      expect(opml).not.toContain('<special>');
+      expect(opml).not.toContain('& characters');
+    });
+
+    it('should handle empty feed list', () => {
+      const opml = OPMLService.exportToOPML([]);
+
+      expect(opml).toContain('<body>');
+      expect(opml).toContain('</body>');
+      expect(opml).not.toContain('<outline');
+    });
+  });
+
+  describe('parseOPML', () => {
+    it('should parse valid OPML and extract URLs', () => {
+      const opml = `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head>
+    <title>Test</title>
+  </head>
+  <body>
+    <outline text="Feed 1" xmlUrl="https://example.com/feed1.rss" />
+    <outline text="Feed 2" xmlUrl="https://example.com/feed2.xml" />
+  </body>
+</opml>`;
+
+      const urls = OPMLService.parseOPML(opml);
+
+      expect(urls).toEqual(['https://example.com/feed1.rss', 'https://example.com/feed2.xml']);
+    });
+
+    it('should handle escaped XML characters', () => {
+      const opml = `<opml>
+  <body>
+    <outline xmlUrl="https://example.com/feed?param=1&amp;other=2" />
+  </body>
+</opml>`;
+
+      const urls = OPMLService.parseOPML(opml);
+
+      expect(urls).toEqual(['https://example.com/feed?param=1&other=2']);
+    });
+
+    it('should ignore invalid URLs', () => {
+      const opml = `<opml>
+  <body>
+    <outline xmlUrl="https://example.com/valid.rss" />
+    <outline xmlUrl="not-a-url" />
+    <outline xmlUrl="ftp://example.com/invalid.rss" />
+    <outline xmlUrl="" />
+  </body>
+</opml>`;
+
+      const urls = OPMLService.parseOPML(opml);
+
+      expect(urls).toEqual(['https://example.com/valid.rss']);
+    });
+
+    it('should handle empty OPML', () => {
+      const opml = `<opml><body></body></opml>`;
+      const urls = OPMLService.parseOPML(opml);
+
+      expect(urls).toEqual([]);
+    });
+  });
+
+  describe('exportToText', () => {
+    it('should export feeds as one URL per line', () => {
+      const text = OPMLService.exportToText(mockFeeds);
+      const lines = text.split('\n');
+
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toBe('https://example.com/feed1.rss');
+      expect(lines[1]).toBe('https://example.com/feed2.xml');
+    });
+
+    it('should handle empty feed list', () => {
+      const text = OPMLService.exportToText([]);
+
+      expect(text).toBe('');
+    });
+  });
+
+  describe('parseText', () => {
+    it('should parse text file with one URL per line', () => {
+      const text = `https://example.com/feed1.rss
+https://example.com/feed2.xml
+https://example.com/feed3.atom`;
+
+      const urls = OPMLService.parseText(text);
+
+      expect(urls).toEqual([
+        'https://example.com/feed1.rss',
+        'https://example.com/feed2.xml',
+        'https://example.com/feed3.atom',
+      ]);
+    });
+
+    it('should ignore empty lines and comments', () => {
+      const text = `https://example.com/feed1.rss
+
+# This is a comment
+https://example.com/feed2.xml
+  
+  https://example.com/feed3.atom  `;
+
+      const urls = OPMLService.parseText(text);
+
+      expect(urls).toEqual([
+        'https://example.com/feed1.rss',
+        'https://example.com/feed2.xml',
+        'https://example.com/feed3.atom',
+      ]);
+    });
+
+    it('should filter out invalid URLs', () => {
+      const text = `https://example.com/valid.rss
+not-a-url
+ftp://example.com/invalid.rss
+http://example.com/also-valid.xml`;
+
+      const urls = OPMLService.parseText(text);
+
+      expect(urls).toEqual(['https://example.com/valid.rss', 'http://example.com/also-valid.xml']);
+    });
+  });
+
+  describe('detectFormat', () => {
+    it('should detect OPML format from .opml extension', () => {
+      expect(OPMLService.detectFormat('feeds.opml')).toBe('opml');
+      expect(OPMLService.detectFormat('FEEDS.OPML')).toBe('opml');
+      expect(OPMLService.detectFormat('/path/to/feeds.opml')).toBe('opml');
+    });
+
+    it('should detect OPML format from .xml extension', () => {
+      expect(OPMLService.detectFormat('feeds.xml')).toBe('opml');
+      expect(OPMLService.detectFormat('FEEDS.XML')).toBe('opml');
+    });
+
+    it('should default to text format for other extensions', () => {
+      expect(OPMLService.detectFormat('feeds.txt')).toBe('text');
+      expect(OPMLService.detectFormat('feeds')).toBe('text');
+      expect(OPMLService.detectFormat('feeds.csv')).toBe('text');
+    });
+  });
+
+  describe('detectFormatFromContent', () => {
+    it('should detect OPML from XML declaration', () => {
+      const content = `<?xml version="1.0"?>
+<opml version="2.0">`;
+
+      expect(OPMLService.detectFormatFromContent(content)).toBe('opml');
+    });
+
+    it('should detect OPML from opml tag', () => {
+      const content = `  <opml version="2.0">
+  <head>`;
+
+      expect(OPMLService.detectFormatFromContent(content)).toBe('opml');
+    });
+
+    it('should default to text for non-XML content', () => {
+      const content = `https://example.com/feed1.rss
+https://example.com/feed2.xml`;
+
+      expect(OPMLService.detectFormatFromContent(content)).toBe('text');
+    });
+
+    it('should handle whitespace correctly', () => {
+      const xmlContent = `  
+      <?xml version="1.0"?>`;
+      const textContent = `  
+      https://example.com/feed.rss`;
+
+      expect(OPMLService.detectFormatFromContent(xmlContent)).toBe('opml');
+      expect(OPMLService.detectFormatFromContent(textContent)).toBe('text');
+    });
+  });
+});

--- a/src/services/opml.ts
+++ b/src/services/opml.ts
@@ -1,0 +1,130 @@
+import { Feed } from '../models/types.js';
+
+export type ExportFormat = 'opml' | 'text';
+
+export class OPMLService {
+  /**
+   * フィード一覧をOPML形式のXMLに変換
+   */
+  static exportToOPML(feeds: Feed[]): string {
+    const now = new Date().toUTCString();
+
+    const outlines = feeds
+      .map((feed) => {
+        const title = this.escapeXml(feed.title || feed.url);
+        const xmlUrl = this.escapeXml(feed.url);
+        const htmlUrl = this.escapeXml(feed.url); // HTMLのURLは通常フィードURLと同じ
+
+        return `    <outline text="${title}" title="${title}" type="rss" xmlUrl="${xmlUrl}" htmlUrl="${htmlUrl}"/>`;
+      })
+      .join('\n');
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head>
+    <title>termfeed subscriptions</title>
+    <dateCreated>${now}</dateCreated>
+    <dateModified>${now}</dateModified>
+  </head>
+  <body>
+${outlines}
+  </body>
+</opml>`;
+  }
+
+  /**
+   * OPML形式のXMLからフィードURLを抽出
+   */
+  static parseOPML(opmlContent: string): string[] {
+    const urls: string[] = [];
+
+    // outline要素からxmlUrl属性を抽出する正規表現
+    const outlineRegex = /<outline[^>]+xmlUrl=["']([^"']+)["'][^>]*>/gi;
+    let match;
+
+    while ((match = outlineRegex.exec(opmlContent)) !== null) {
+      const url = this.unescapeXml(match[1]);
+      if (url && this.isValidUrl(url)) {
+        urls.push(url);
+      }
+    }
+
+    return urls;
+  }
+
+  /**
+   * XML特殊文字をエスケープ
+   */
+  private static escapeXml(str: string): string {
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  }
+
+  /**
+   * XMLエスケープを解除
+   */
+  private static unescapeXml(str: string): string {
+    return str
+      .replace(/&apos;/g, "'")
+      .replace(/&quot;/g, '"')
+      .replace(/&gt;/g, '>')
+      .replace(/&lt;/g, '<')
+      .replace(/&amp;/g, '&');
+  }
+
+  /**
+   * URLの妥当性をチェック
+   */
+  private static isValidUrl(url: string): boolean {
+    try {
+      const parsed = new globalThis.URL(url);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * フィード一覧をテキスト形式（1行1URL）に変換
+   */
+  static exportToText(feeds: Feed[]): string {
+    return feeds.map((feed) => feed.url).join('\n');
+  }
+
+  /**
+   * テキスト形式（1行1URL）からフィードURLを抽出
+   */
+  static parseText(textContent: string): string[] {
+    return textContent
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('#')) // 空行とコメント行を除外
+      .filter((url) => this.isValidUrl(url));
+  }
+
+  /**
+   * ファイル拡張子から形式を判定
+   */
+  static detectFormat(filename: string): ExportFormat {
+    const ext = filename.toLowerCase().split('.').pop();
+    if (ext === 'opml' || ext === 'xml') {
+      return 'opml';
+    }
+    return 'text';
+  }
+
+  /**
+   * コンテンツから形式を判定
+   */
+  static detectFormatFromContent(content: string): ExportFormat {
+    const trimmed = content.trim();
+    if (trimmed.startsWith('<?xml') || trimmed.includes('<opml')) {
+      return 'opml';
+    }
+    return 'text';
+  }
+}


### PR DESCRIPTION
## Summary
- OPMLおよびテキスト形式でのフィードのエクスポート/インポート機能を実装
- 他のRSSリーダーとのデータ移行を可能に
- デフォルトファイル名を`subscriptions.opml`に設定

## 実装内容

### エクスポート機能 (`termfeed export`)
- OPML形式（デフォルト）とテキスト形式（1行1URL）をサポート
- ファイル拡張子による自動形式判定（.opml/.xml → OPML、.txt → テキスト）
- `--format`オプションで明示的な形式指定も可能
- XMLエスケープ処理を適切に実装

### インポート機能 (`termfeed import`)
- OPML形式とテキスト形式の自動判別
- 重複URLの自動スキップ（エラーにせずに警告表示）
- テキスト形式でのコメント行（#で始まる）サポート
- インポート結果のサマリー表示（成功/スキップ/失敗の件数）

### 技術的な詳細
- 外部ライブラリを使わず自前実装（依存関係を増やさない）
- 包括的なテストカバレッジ（OPMLService.test.ts）
- セキュアな実装（URLバリデーション、XMLエスケープ処理）

### 修正
- FeedServiceのコンストラクタ引数エラーを修正（CI失敗への対応）

## Test plan
- [x] `npm run test:run src/services/opml.test.ts` でテストが通ることを確認
- [x] `npm run lint` でlintエラーがないことを確認
- [x] `npm run test:run` で全テストが通ることを確認
- [ ] 実際にOPMLファイルをエクスポート/インポートして動作確認
- [ ] テキストファイルでのエクスポート/インポートも動作確認
- [ ] 他のRSSリーダー（Feedly等）からエクスポートしたOPMLファイルをインポートできることを確認