### PR TITLE
fix: データベースファイルパスの不整合を修正 (#22)

### DIFF
--- a/src/cli/commands/export.ts
+++ b/src/cli/commands/export.ts
@@ -2,16 +2,16 @@ import { Command } from 'commander';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import chalk from 'chalk';
-import { DatabaseManager } from '../../models/database.js';
 import { FeedModel } from '../../models/feed.js';
 import { OPMLService, ExportFormat } from '../../services/opml.js';
+import { createDatabaseManager } from '../utils/database.js';
 
 export const exportCommand = new Command('export')
   .description('Export feed subscriptions to OPML or text file')
   .argument('[file]', 'output file path (default: subscriptions.opml)')
   .option('-f, --format <format>', 'export format (opml or text)', 'auto')
   .action(async (file?: string, options?: { format?: string }) => {
-    const dbManager = new DatabaseManager();
+    const dbManager = createDatabaseManager();
 
     try {
       dbManager.migrate();

--- a/src/cli/commands/import.ts
+++ b/src/cli/commands/import.ts
@@ -8,6 +8,7 @@ import { ArticleModel } from '../../models/article.js';
 import { FeedService } from '../../services/feed-service.js';
 import { OPMLService } from '../../services/opml.js';
 import { DuplicateFeedError } from '../../services/errors.js';
+import { createDatabaseManager } from '../utils/database.js';
 
 export const importCommand = new Command('import')
   .description('Import feed subscriptions from OPML or text file')
@@ -57,7 +58,7 @@ export const importCommand = new Command('import')
       console.log(chalk.blue(`Found ${urls.length} feed URLs to import...`));
 
       // データベースとサービスの初期化
-      dbManager = new DatabaseManager();
+      dbManager = createDatabaseManager();
       dbManager.migrate();
       const feedModel = new FeedModel(dbManager);
       const articleModel = new ArticleModel(dbManager);

--- a/src/cli/utils/database.ts
+++ b/src/cli/utils/database.ts
@@ -1,6 +1,15 @@
 import { DatabaseManager } from '../../models/database.js';
+import * as path from 'path';
+import * as os from 'os';
 
-export const DEFAULT_DB_PATH = './termfeed.db';
+export function getDefaultDbPath(): string {
+  // XDG Base Directory specificationに従う
+  const xdgDataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+  const dataDir = path.join(xdgDataHome, 'termfeed');
+  return path.join(dataDir, 'termfeed.db');
+}
+
+export const DEFAULT_DB_PATH = getDefaultDbPath();
 
 export function getDatabasePath(): string {
   return process.env.TERMFEED_DB || DEFAULT_DB_PATH;

--- a/src/models/database.ts
+++ b/src/models/database.ts
@@ -19,8 +19,10 @@ export class DatabaseManager {
   }
 
   private getDefaultDbPath(): string {
-    const configDir = path.join(os.homedir(), '.termfeed');
-    return path.join(configDir, 'termfeed.db');
+    // XDG Base Directory specificationに従う
+    const xdgDataHome = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
+    const dataDir = path.join(xdgDataHome, 'termfeed');
+    return path.join(dataDir, 'termfeed.db');
   }
 
   private ensureDbDirectory(): void {


### PR DESCRIPTION
## 概要
Issue #22 で報告されたデータベースファイルパスの不整合を修正しました。

## 問題点
- import/exportコマンドが `new DatabaseManager()` を使用していたため、デフォルトパスが `~/.termfeed/termfeed.db` になっていた
- 他のコマンド（add、list、articles、update、rm、tui）は `createDatabaseManager()` を使用し、デフォルトパスが `./termfeed.db` だった
- このため、import/exportコマンドと他のコマンドで異なるデータベースファイルを参照していた

## 修正内容
1. **データベースパスの統一**
   - import/exportコマンドを `createDatabaseManager()` を使用するように変更
   - 全コマンドで同じデータベースファイルを参照するように統一

2. **XDG Base Directory準拠**
   - デフォルトのデータベースパスを `~/.local/share/termfeed/termfeed.db` に変更
   - 環境変数 `$XDG_DATA_HOME` が設定されている場合はそれを優先
   - データファイルとして適切な場所（XDG_DATA_HOME）に配置

## 動作確認
- [x] 全テストが成功することを確認
- [x] lint/typecheckが通ることを確認
- [x] フィードの追加・表示・エクスポートが正常に動作することを確認
- [x] TUIモードで正しくフィードが表示されることを確認

## 破壊的変更
既存ユーザーは新しいパス（`~/.local/share/termfeed/termfeed.db`）にデータベースファイルが作成されます。
既存のデータベースファイル（`./termfeed.db` または `~/.termfeed/termfeed.db`）からのデータ移行が必要な場合は、手動で対応が必要です。

Fixes #22