### PR TITLE
fix: CI で落ちている自動既読機能のテストを修正

### DIFF
--- a/src/apps/tui/App.autoread.test.tsx
+++ b/src/apps/tui/App.autoread.test.tsx
@@ -147,13 +147,16 @@ describe('App - 自動既読機能', () => {
   it('フィード移動時に選択中の未読記事を既読にする', async () => {
     const { stdin, unmount } = render(<App />);
 
-    // 初期化が完了するまで待機
+    // 初期化が完了し、最初の記事が閲覧記録されるまで待機
     await vi.waitFor(
       () => {
         expect(mockFeedService.getArticles).toHaveBeenCalled();
       },
       { timeout: 1000 }
     );
+
+    // 記事の表示が完了するまで少し待機（useEffectの実行を待つ）
+    await new Promise((resolve) => setTimeout(resolve, 100));
 
     // sキーでフィード2に移動
     stdin.write('s');


### PR DESCRIPTION
## 修正内容

GitHub Actions の CI で落ちていた `App.autoread.test.tsx` のテスト「フィード移動時に選択中の未読記事を既読にする」を修正しました。

## 問題の原因

テストでは `s` キーでフィード移動した際に記事が既読化されることを期待していましたが、実装では以下の流れで処理されます：

1. App.tsx の `useEffect` で初期表示時に最初の記事を `recordArticleView()` で閲覧記録
2. フィード移動時に `handleFeedSelectionChange` → `markViewedArticlesAsRead()` が呼ばれる
3. 閲覧記録された記事を一括で既読化

テストでは `useEffect` の実行を待たずにすぐに `s` キーを押していたため、閲覧記録が空の状態でフィード移動が発生し、既読化処理が実行されませんでした。

## 修正方法

`getArticles` の呼び出し確認後、`useEffect` による初期記事の閲覧記録が完了するまで 100ms 待機する処理を追加しました。

```typescript
// 記事の表示が完了するまで少し待機（useEffectの実行を待つ）
await new Promise((resolve) => setTimeout(resolve, 100));
```

## テスト結果

修正後、全274個のテストが成功することを確認しました。

```
Test Files  28 passed (28)
     Tests  274 passed (274)
```