### PR TITLE
fix: バージョン番号をpackage.jsonから動的に読み込むように変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "termfeed",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "termfeed",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termfeed",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A terminal-based RSS reader with Vim-like keybindings",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@
 
 import { Command } from 'commander';
 import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { readFileSync } from 'fs';
 import {
   createAddCommand,
   createRmCommand,
@@ -11,7 +13,11 @@ import {
   createMcpServerCommand,
 } from './apps/cli/commands/index.js';
 
-export const VERSION = '0.1.0';
+// package.jsonからバージョンを動的に読み込む
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJsonPath = join(__dirname, '../package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { version: string };
+export const VERSION = packageJson.version;
 
 /**
  * CLIのメインプログラムを作成します。


### PR DESCRIPTION
## 概要

src/index.tsでハードコードされていたバージョン番号を、package.jsonから動的に読み込むように変更しました。

## 問題点

現在、バージョン番号が2箇所で管理されていました：
- `package.json`: `"version": "0.1.0"`
- `src/index.ts`: `export const VERSION = '0.1.0';`

これにより、`npm version`コマンドを実行してもsrc/index.tsは更新されず、手動での修正が必要でした。

## 解決策

src/index.tsでpackage.jsonからバージョンを動的に読み込むように変更：
```typescript
const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as { version: string };
export const VERSION = packageJson.version;
```

## メリット

- `npm version`コマンドだけでバージョン管理が完結
- バージョンの不整合が発生しない
- メンテナンスが容易

## 動作確認

```bash
npm run build && npm start -- --version
# 0.1.1
```

## 注意事項

このPRには0.1.1へのバージョンアップも含まれていますが、実際のバージョンアップはPRマージ後にmainブランチで行う予定です。