### PR TITLE
fix: CLIヘルプメッセージの統一性を改善

### DIFF
--- a/src/apps/cli/commands/export.ts
+++ b/src/apps/cli/commands/export.ts
@@ -9,7 +9,7 @@ import { createDatabaseManager } from '../utils/database.js';
 export const exportCommand = new Command('export')
   .description('Export feed subscriptions to OPML or text file')
   .argument('[file]', 'output file path (default: subscriptions.opml)')
-  .option('-f, --format <format>', 'export format (opml or text)', 'auto')
+  .option('-f, --format <format>', 'Export format (opml or text)', 'auto')
   .action(async (file?: string, options?: { format?: string }) => {
     const dbManager = createDatabaseManager();
 

--- a/src/apps/cli/commands/import.ts
+++ b/src/apps/cli/commands/import.ts
@@ -13,7 +13,7 @@ import { createDatabaseManager } from '../utils/database.js';
 export const importCommand = new Command('import')
   .description('Import feed subscriptions from OPML or text file')
   .argument('<file>', 'file to import')
-  .option('-f, --format <format>', 'import format (opml or text)', 'auto')
+  .option('-f, --format <format>', 'Import format (opml or text)', 'auto')
   .action(async (file: string, options?: { format?: string }) => {
     let dbManager: DatabaseManager | null = null;
 

--- a/src/apps/cli/commands/tui.tsx
+++ b/src/apps/cli/commands/tui.tsx
@@ -5,7 +5,7 @@ import { App } from '../../tui/App.js';
 export function createTuiCommand(): Command {
   const tuiCommand = new Command('tui');
 
-  tuiCommand.description('TUIモードでRSSリーダーを起動').action(() => {
+  tuiCommand.description('Start RSS reader in TUI mode').action(() => {
     try {
       // TUIアプリケーション内でマイグレーションが実行される
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,8 @@ export function createMainProgram(): Command {
   program
     .name('termfeed')
     .description('A terminal-based RSS reader with Vim-like keybindings')
-    .version(VERSION);
+    .version(VERSION)
+    .addHelpCommand('help [command]', 'Display help for command');
 
   // Register subcommands
   program.addCommand(createAddCommand());


### PR DESCRIPTION
- すべてのコマンドdescriptionを大文字始まりに統一
- オプションの説明も大文字始まりに統一
- Commanderデフォルトのhelpコマンドの説明も統一