### PR TITLE
fix: 未読記事取得ロジックの改善とパフォーマンス最適化

### DIFF
--- a/src/apps/tui/__tests__/App.integration.test.tsx
+++ b/src/apps/tui/__tests__/App.integration.test.tsx
@@ -750,9 +750,10 @@ describe('App Integration Tests', () => {
       });
     });
 
-    it('上限以上の未読記事がある場合、最新の制限件数分のみ取得される', async () => {
-      // 150件の未読記事を持つフィードをシミュレート
-      const manyArticles = Array.from({ length: 150 }, (_, i) => ({
+    it('制限件数を超える未読記事がある場合、制限件数分のみ取得される', async () => {
+      // 制限件数（100件）を超える記事をシミュレート
+      // 実際のgetArticlesは制限件数分のみ返すため、100件のモックデータを作成
+      const limitedArticles = Array.from({ length: 100 }, (_, i) => ({
         id: i + 1,
         feed_id: 1,
         title: `Article ${i + 1}`,
@@ -767,8 +768,7 @@ describe('App Integration Tests', () => {
         updated_at: new Date('2024-01-01T00:00:00Z'),
       }));
 
-      // DBには150件あるが、TUIには最新100件のみが返される
-      const limitedArticles = manyArticles.slice(0, 100);
+      // getArticlesは制限件数（100件）分の記事を返す
       mockFeedService.getArticles.mockReturnValue(limitedArticles);
 
       const { lastFrame } = render(<App />);
@@ -782,11 +782,11 @@ describe('App Integration Tests', () => {
         });
       });
 
-      // 最新の記事（Article 1）が表示され、古い記事（Article 150）は表示されない
+      // 制限件数分の記事が正しく表示される
       await vi.waitFor(() => {
         const frame = lastFrame();
-        expect(frame).toContain('Article 1');
-        expect(frame).not.toContain('Article 150');
+        expect(frame).toContain('Article 1'); // 最初の記事
+        expect(frame).toContain('1/100件'); // 件数表示の確認
       });
     });
 

--- a/src/apps/tui/__tests__/App.integration.test.tsx
+++ b/src/apps/tui/__tests__/App.integration.test.tsx
@@ -315,7 +315,7 @@ describe('App Integration Tests', () => {
       await vi.waitFor(() => {
         expect(mockFeedService.getArticles).toHaveBeenCalledWith({
           feed_id: 2,
-          limit: 100,
+          is_read: false,
         });
       });
     });
@@ -338,7 +338,7 @@ describe('App Integration Tests', () => {
       await vi.waitFor(() => {
         const calls = mockFeedService.getArticles.mock.calls;
         const lastCall = calls[calls.length - 1];
-        expect(lastCall).toEqual([{ feed_id: 1, limit: 100 }]);
+        expect(lastCall).toEqual([{ feed_id: 1, is_read: false }]);
       });
     });
 
@@ -794,7 +794,7 @@ describe('App Integration Tests', () => {
         () => {
           expect(mockFeedService.getArticles).toHaveBeenCalledWith({
             feed_id: 11,
-            limit: 100,
+            is_read: false,
           });
         },
         { timeout: 3000 }
@@ -882,7 +882,7 @@ describe('App Integration Tests', () => {
       // getArticlesが複数回呼ばれていることを確認
       expect(mockFeedService.getArticles).toHaveBeenCalledWith({
         feed_id: 2,
-        limit: 100,
+        is_read: false,
       });
 
       // aキーで前のフィードに戻る
@@ -895,7 +895,7 @@ describe('App Integration Tests', () => {
       // Feed 1に戻っていることを確認
       expect(mockFeedService.getArticles).toHaveBeenCalledWith({
         feed_id: 1,
-        limit: 100,
+        is_read: false,
       });
     });
 
@@ -947,13 +947,13 @@ describe('App Integration Tests', () => {
       // Feed 2が選択されたままであることを確認
       expect(mockFeedService.getArticles).toHaveBeenLastCalledWith({
         feed_id: 2,
-        limit: 100,
+        is_read: false,
       });
 
       // Feed 1への移動は発生していない
       expect(mockFeedService.getArticles).not.toHaveBeenCalledWith({
         feed_id: 1,
-        limit: 100,
+        is_read: false,
       });
     });
   });
@@ -974,7 +974,7 @@ describe('App Integration Tests', () => {
       await vi.waitFor(() => {
         expect(mockFeedService.getArticles).toHaveBeenLastCalledWith({
           feed_id: 2,
-          limit: 100,
+          is_read: false,
         });
       });
 
@@ -1000,7 +1000,7 @@ describe('App Integration Tests', () => {
       // Feed 2が引き続き選択されていることを確認
       expect(mockFeedService.getArticles).toHaveBeenLastCalledWith({
         feed_id: 2,
-        limit: 100,
+        is_read: false,
       });
     });
 
@@ -1018,7 +1018,7 @@ describe('App Integration Tests', () => {
       await vi.waitFor(() => {
         expect(mockFeedService.getArticles).toHaveBeenCalledWith({
           feed_id: 2,
-          limit: 100,
+          is_read: false,
         });
       });
 

--- a/src/apps/tui/__tests__/App.integration.test.tsx
+++ b/src/apps/tui/__tests__/App.integration.test.tsx
@@ -708,11 +708,10 @@ describe('App Integration Tests', () => {
 
   describe('記事のフィルタリング', () => {
     it('既読記事は表示されない', async () => {
-      // useArticleManagerが未読記事のみをフィルタリングするため、
-      // getArticlesはすべての記事を返し、フック内でフィルタリングされる
+      // データベースから直接未読記事のみを取得するため、
+      // getArticlesは未読記事のみを返す
       mockFeedService.getArticles.mockReturnValue([
-        { ...mockArticles[0], is_read: true },
-        { ...mockArticles[1], is_read: false },
+        { ...mockArticles[1], is_read: false }, // Article 2のみ（未読）
       ]);
 
       const { lastFrame } = render(<App />);

--- a/src/apps/tui/__tests__/App.integration.test.tsx
+++ b/src/apps/tui/__tests__/App.integration.test.tsx
@@ -316,6 +316,7 @@ describe('App Integration Tests', () => {
         expect(mockFeedService.getArticles).toHaveBeenCalledWith({
           feed_id: 2,
           is_read: false,
+          limit: 100,
         });
       });
     });
@@ -338,7 +339,7 @@ describe('App Integration Tests', () => {
       await vi.waitFor(() => {
         const calls = mockFeedService.getArticles.mock.calls;
         const lastCall = calls[calls.length - 1];
-        expect(lastCall).toEqual([{ feed_id: 1, is_read: false }]);
+        expect(lastCall).toEqual([{ feed_id: 1, is_read: false, limit: 100 }]);
       });
     });
 
@@ -794,6 +795,7 @@ describe('App Integration Tests', () => {
           expect(mockFeedService.getArticles).toHaveBeenCalledWith({
             feed_id: 11,
             is_read: false,
+            limit: 100,
           });
         },
         { timeout: 3000 }
@@ -882,6 +884,7 @@ describe('App Integration Tests', () => {
       expect(mockFeedService.getArticles).toHaveBeenCalledWith({
         feed_id: 2,
         is_read: false,
+        limit: 100,
       });
 
       // aキーで前のフィードに戻る
@@ -895,6 +898,7 @@ describe('App Integration Tests', () => {
       expect(mockFeedService.getArticles).toHaveBeenCalledWith({
         feed_id: 1,
         is_read: false,
+        limit: 100,
       });
     });
 
@@ -947,12 +951,14 @@ describe('App Integration Tests', () => {
       expect(mockFeedService.getArticles).toHaveBeenLastCalledWith({
         feed_id: 2,
         is_read: false,
+        limit: 100,
       });
 
       // Feed 1への移動は発生していない
       expect(mockFeedService.getArticles).not.toHaveBeenCalledWith({
         feed_id: 1,
         is_read: false,
+        limit: 100,
       });
     });
   });
@@ -974,6 +980,7 @@ describe('App Integration Tests', () => {
         expect(mockFeedService.getArticles).toHaveBeenLastCalledWith({
           feed_id: 2,
           is_read: false,
+          limit: 100,
         });
       });
 
@@ -1000,6 +1007,7 @@ describe('App Integration Tests', () => {
       expect(mockFeedService.getArticles).toHaveBeenLastCalledWith({
         feed_id: 2,
         is_read: false,
+        limit: 100,
       });
     });
 
@@ -1018,6 +1026,7 @@ describe('App Integration Tests', () => {
         expect(mockFeedService.getArticles).toHaveBeenCalledWith({
           feed_id: 2,
           is_read: false,
+          limit: 100,
         });
       });
 

--- a/src/apps/tui/hooks/useArticleManager.ts
+++ b/src/apps/tui/hooks/useArticleManager.ts
@@ -46,11 +46,12 @@ export function useArticleManager(
         setError('');
 
         // データベースから直接未読記事のみを取得（上限付き）
-        const unreadArticles = feedService.getArticles({
-          feed_id: feedId,
-          is_read: false,
-          limit: TUI_CONFIG.DEFAULT_ARTICLE_LIMIT,
-        });
+        const unreadArticles =
+          feedService.getArticles({
+            feed_id: feedId,
+            is_read: false,
+            limit: TUI_CONFIG.DEFAULT_ARTICLE_LIMIT,
+          }) || []; // 防御的プログラミング
         setArticles(unreadArticles);
         setSelectedArticleIndex(0);
         setScrollOffset(0); // スクロール位置をリセット

--- a/src/apps/tui/hooks/useArticleManager.ts
+++ b/src/apps/tui/hooks/useArticleManager.ts
@@ -45,12 +45,11 @@ export function useArticleManager(
         setIsLoading(true);
         setError('');
 
-        const allArticles = feedService.getArticles({
+        // データベースから直接未読記事のみを取得
+        const unreadArticles = feedService.getArticles({
           feed_id: feedId,
-          limit: TUI_CONFIG.DEFAULT_ARTICLE_LIMIT,
+          is_read: false,
         });
-        // 未読記事のみをフィルタリング（防御的プログラミング）
-        const unreadArticles = (allArticles || []).filter((article) => !article.is_read);
         setArticles(unreadArticles);
         setSelectedArticleIndex(0);
         setScrollOffset(0); // スクロール位置をリセット

--- a/src/apps/tui/hooks/useArticleManager.ts
+++ b/src/apps/tui/hooks/useArticleManager.ts
@@ -45,10 +45,11 @@ export function useArticleManager(
         setIsLoading(true);
         setError('');
 
-        // データベースから直接未読記事のみを取得
+        // データベースから直接未読記事のみを取得（上限付き）
         const unreadArticles = feedService.getArticles({
           feed_id: feedId,
           is_read: false,
+          limit: TUI_CONFIG.DEFAULT_ARTICLE_LIMIT,
         });
         setArticles(unreadArticles);
         setSelectedArticleIndex(0);


### PR DESCRIPTION
## 修正内容

大量の記事を持つフィードで、すべての未読記事が表示されない問題を修正しました。

### 修正前の問題
- データベースから最大100件の記事を取得後、アプリケーション側で未読記事をフィルタリングしていた
- 結果として、300件以上の記事があるフィードでは未読記事の一部が表示されない状態になっていた
- パフォーマンス面でも非効率的だった

### 修正後の改善
- **SQLクエリ最適化**: `is_read = false` の条件をデータベースレベルで追加
- **アプリケーション層の簡素化**: 不要なフィルタリング処理を削除
- **安全な上限設定**: パフォーマンスを考慮して100件制限を維持
- **防御的プログラミング**: エラーハンドリングの強化（`|| []` フォールバック）
- **包括的テスト追加**: 大量フィードと既読化後の動作を保証

### パフォーマンス向上
- データベースから取得するレコード数が大幅に削減される
- アプリケーション側での不要なフィルタリング処理が削除される
- メモリ使用量の制御（1万件フィードでも安全）

### 修正箇所
- `src/apps/tui/hooks/useArticleManager.ts` の記事取得ロジック
- テストコードの期待値とモックデータの修正
- 新しいテストケースの追加（大量フィード、既読化後の再取得）

### コード品質改善
1. **防御的プログラミング**: `getArticles` に `|| []` フォールバック処理を再追加
2. **テスト命名の整合性**: 「制限件数を超える未読記事」に修正し、実装と命名を一致
3. **テスト検証の改善**: より実用的で意味のある検証内容に変更

### 新しく追加されたテスト
1. **制限件数を超える未読記事のテスト**: 制限件数（100件）が正しく動作することを確認
2. **既読化後の再取得テスト**: 記事を既読化した後、残りの未読記事が正しく取得される

これにより、「おそらくはそれさえも平凡な日々」のような300件以上の記事があるフィードでも、安全かつ効率的に最新100件の未読記事が表示されるようになります。将来のページネーション実装への準備も整いました。