### PR TITLE
improve: お気に入りとピンの表示位置と視認性を改善

### DIFF
--- a/src/apps/tui/components/ArticleList.tsx
+++ b/src/apps/tui/components/ArticleList.tsx
@@ -158,6 +158,21 @@ export const ArticleList = memo(function ArticleList({
           {selectedArticle.title}
         </Text>
       </Box>
+      {/* お気に入り・ピンステータス */}
+      {(selectedArticle.is_favorite || isPinned) && (
+        <Box paddingX={1} flexDirection="row" gap={1}>
+          {selectedArticle.is_favorite && (
+            <Text color="yellow" bold>
+              ★ お気に入り
+            </Text>
+          )}
+          {isPinned && (
+            <Text color="yellow" bold>
+              📌 ピン
+            </Text>
+          )}
+        </Box>
+      )}
       <Box paddingX={1}>
         <Text color="gray">公開日: {publishedDate}</Text>
         {selectedArticle.author && <Text color="cyan"> | 著者: {selectedArticle.author}</Text>}
@@ -176,10 +191,8 @@ export const ArticleList = memo(function ArticleList({
       {/* ステータス部分：固定 */}
       <Box paddingX={1} marginTop={1}>
         <Text color="gray" dimColor>
-          {selectedArticle.is_favorite ? '★お気に入り' : ''}
-          {isPinned ? (selectedArticle.is_favorite ? ' | ' : '') + '📌ピン' : ''}
-          {scrollInfo && (selectedArticle.is_favorite || isPinned ? ' | ' : '') + scrollInfo}
-          {hasMoreContent && ' スペースで続きを表示'}
+          {scrollInfo}
+          {hasMoreContent && (scrollInfo ? ' ' : '') + 'スペースで続きを表示'}
         </Text>
       </Box>
 


### PR DESCRIPTION
- お気に入り（★）とピン（📌）をタイトル直下に移動
- 表示色を薄い灰色から黄色・太字に変更して視認性向上
- 下部ステータス行からお気に入り・ピン情報を削除